### PR TITLE
Option All Songs for All Artists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+ADD OPTION ALL SONGS FOR ALL ARTISTS
+
+
 English / [简体中文](./README-CN.md)
 
 ### ！！Must be installed first [MP4Box](https://gpac.io/downloads/gpac-nightly-builds/)，And confirm [MP4Box](https://gpac.io/downloads/gpac-nightly-builds/) Correctly added to environment variables


### PR DESCRIPTION
Is it possible to have an option to find all songs for an artist even when the songs are not on albums by that artists?
This is basically what the "--include-participate-songs" option does for [WorldObservationLog's AppleMusicDecrypt](https://github.com/WorldObservationLog/AppleMusicDecrypt).

Example:
The song
https://music.apple.com/us/song/listen-to-your-heart/1786748237
should show us when searching for artist
https://music.apple.com/us/artist/medina/476902236.

Thanks!