### PR TITLE
Fix incorrect cover art when downloading songs from a playlist

### DIFF
--- a/main.go
+++ b/main.go
@@ -1781,7 +1781,20 @@ func ripPlaylist(playlistId string, token string, storefront string, mediaUserTo
 	}
 
 	for i := range playlist.Tracks {
-		playlist.Tracks[i].CoverPath = covPath
+		os.MkdirAll("./covers", os.ModePerm)
+		songCovPath, err := writeCover(
+			playlistFolderPath,
+			playlist.Tracks[i].Resp.Attributes.Name, 
+			playlist.Tracks[i].Resp.Attributes.Artwork.URL);
+		if err != nil {
+			fmt.Println("Failed to write cover.")
+		}
+
+		if (songCovPath != "") {
+			playlist.Tracks[i].CoverPath = songCovPath;
+		} else {
+			playlist.Tracks[i].CoverPath = covPath;
+		}
 		playlist.Tracks[i].SaveDir = playlistFolderPath
 		playlist.Tracks[i].Codec = Codec
 	}


### PR DESCRIPTION
Problem:
When downloading tracks from a playlist, the cover art was incorrectly taken from the playlist itself, rather than from each individual song. This resulted in all songs sharing the same playlist cover.

Fix:
Now the downloader fetches and assigns the correct cover art for each track based on its own metadata (Attributes.Artwork.URL), ensuring each song gets its own artwork.