### PR TITLE
fix: default get-m3u8-mode to all to fix Invalid CKC / EOF, and improve runv2 stream reliability

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -29,8 +29,8 @@ get-account-from-device: false   #if set true,will auto get media-user-token
 # set to 'true' to exit on error instead of requiring manual intervention. (for using this program in scripts)
 exit-on-error: false
 
-#set 'all' to retrieve all m3u8, and set 'hires' to only detect hires m3u8.
-get-m3u8-mode: hires # all hires
+# set 'all' to retrieve all m3u8 from device (recommended to avoid Invalid CKC on standard ALAC), or 'hires' to only detect hires m3u8.
+get-m3u8-mode: all # all hires
 aac-type: aac-lc # aac-lc aac aac-binaural aac-downmix
 alac-max: 192000  #192000 96000 48000 44100
 atmos-max: 2768  #2768 2448

--- a/utils/runv2/runv2.go
+++ b/utils/runv2/runv2.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"time"
 
+	"main/utils/httputil"
 	"main/utils/structs"
 
 	"github.com/grafov/m3u8"
@@ -57,7 +58,7 @@ func Run(adamId string, playlistUrl string, outfile string, Config structs.Confi
 	}
 	req.Header = header
 	// requesting an HLS playlist should be relatively fast, so we set the timeout directly on the client
-	do, err := (&http.Client{Timeout: timeout}).Do(req)
+	do, err := (&http.Client{Timeout: timeout, Transport: httputil.Client.Transport}).Do(req)
 	if err != nil {
 		return err
 	}
@@ -95,7 +96,7 @@ func Run(adamId string, playlistUrl string, outfile string, Config structs.Confi
 	req.Header = header
 
 	var body io.Reader
-	client := &http.Client{Timeout: timeout}
+	client := &http.Client{Timeout: timeout, Transport: httputil.Client.Transport}
 	if optstimeout > 0 {
 		// create the timer before calling Do so that the timeout covers TCP handshake,
 		// TLS handshake, sending the request and receiving HTTP headers
@@ -137,7 +138,13 @@ func Run(adamId string, playlistUrl string, outfile string, Config structs.Confi
 					BarEnd:        "",
 				}),
 			)
-			io.Copy(io.MultiWriter(&buffer, bar), do.Body)
+			n, err := io.Copy(io.MultiWriter(&buffer, bar), do.Body)
+			if err != nil {
+				return fmt.Errorf("download stream error: %w", err)
+			}
+			if do.ContentLength > 0 && n < do.ContentLength {
+				return fmt.Errorf("download incomplete (%d/%d bytes downloaded)", n, do.ContentLength)
+			}
 			body = &buffer
 			fmt.Print("Downloaded\n")
 		} else {


### PR DESCRIPTION
### Summary of Changes

1. **Default `get-m3u8-mode` to `all` in `config.yaml.example`**:
   - **Problem**: When `get-m3u8-mode` was defaulted to `hires`, any standard ALAC tracks (e.g. 16-bit/44.1kHz or 24-bit/44.1kHz/48kHz) not flagged as `hi-res-lossless` bypassed querying the device (`checkM3u8` via wrapper port 20020), falling back to `track.WebM3u8` from the Web API.
   - The Web API's HLS playlist uses web-specific FairPlay DRM key URIs (e.g. `skd://itunes.apple.com/.../c23`). When passed to the Android-based wrapper (`10020`), the Android DRM engine cannot obtain keys for web-profile streams, throwing `[!] catched an exception: Invalid CKC error.` and abruptly closing the TCP connection with `Failed to run v2: decryptFragment: EOF`.
   - Setting `get-m3u8-mode: all` ensures all tracks retrieve Android-compatible streams from wrapper (e.g. `skd://itunes.apple.com/.../c6`), allowing standard ALAC tracks to decrypt with 100% success.

2. **Improve `runv2` download stream reliability**:
   - Route `runv2` HTTP requests through `httputil.Client.Transport` so that proxies configured in `config.yaml` are respected during playlist and media fragment downloads.
   - Add verification to `io.Copy` in `runv2`: check for read errors and ensure the downloaded byte count matches `ContentLength` before feeding the buffer into decryption, preventing truncated files from causing `read box body length does not match expected length` errors.