### PR TITLE
fix: default get-m3u8-mode to all to resolve Invalid CKC / EOF, and verify download stream integrity

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -29,8 +29,8 @@ get-account-from-device: false   #if set true,will auto get media-user-token
 # set to 'true' to exit on error instead of requiring manual intervention. (for using this program in scripts)
 exit-on-error: false
 
-#set 'all' to retrieve all m3u8, and set 'hires' to only detect hires m3u8.
-get-m3u8-mode: hires # all hires
+# set 'all' to retrieve all m3u8 from device (recommended to avoid Invalid CKC on standard ALAC), or 'hires' to only detect hires m3u8.
+get-m3u8-mode: all # all hires
 aac-type: aac-lc # aac-lc aac aac-binaural aac-downmix
 alac-max: 192000  #192000 96000 48000 44100
 atmos-max: 2768  #2768 2448

--- a/utils/runv2/runv2.go
+++ b/utils/runv2/runv2.go
@@ -137,7 +137,13 @@ func Run(adamId string, playlistUrl string, outfile string, Config structs.Confi
 					BarEnd:        "",
 				}),
 			)
-			io.Copy(io.MultiWriter(&buffer, bar), do.Body)
+			n, err := io.Copy(io.MultiWriter(&buffer, bar), do.Body)
+			if err != nil {
+				return fmt.Errorf("download stream error: %w", err)
+			}
+			if do.ContentLength > 0 && n < do.ContentLength {
+				return fmt.Errorf("download incomplete (%d/%d bytes downloaded)", n, do.ContentLength)
+			}
 			body = &buffer
 			fmt.Print("Downloaded\n")
 		} else {


### PR DESCRIPTION
### Summary of Changes

1. **Default `get-m3u8-mode` to `all` in `config.yaml.example`**:
   - **Problem**: When `get-m3u8-mode` is set to `hires` (the previous default), standard ALAC tracks (16-bit/44.1kHz or 24-bit/44.1kHz/48kHz) that are not flagged as `hi-res-lossless` bypass `checkM3u8` from the device (wrapper:20020), falling back to `track.WebM3u8` from the Web API.
   - The Web API's HLS playlist uses web-specific FairPlay DRM key URIs (e.g. `skd://itunes.apple.com/.../c23`). When passed to the Android-based wrapper (`10020`), the Android FairPlay library cannot obtain keys for web-profile streams, throwing `[!] catched an exception: Invalid CKC error.` and abruptly closing the TCP connection with `Failed to run v2: decryptFragment: EOF`.
   - Setting `get-m3u8-mode: all` ensures all ALAC tracks retrieve Android-compatible streams directly from wrapper (e.g. `skd://itunes.apple.com/.../c6`), allowing standard ALAC tracks to decrypt with 100% success.

2. **Verify download stream completeness in `runv2.go`**:
   - In `runv2.go`, `io.Copy(io.MultiWriter(&buffer, bar), do.Body)` previously discarded the returned byte count and error. If a connection dropped or timed out mid-stream, it would still print `Downloaded` and pass the truncated buffer to `downloadAndDecryptFile`, triggering confusing parser errors like `read box body length xxx does not match expected length xxx`.
   - Added checks for read errors and verified that downloaded bytes match `ContentLength` before proceeding to decryption.