### PR TITLE
fix(runv4): fix 4MB download stalls and add flexible key-server response parsing (wrapper-lite https://github.com/WorldObservationLog/wrapper/tree/lite)

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -18,12 +18,12 @@ atmos-save-folder: AM-DL-Atmos downloads
 aac-save-folder: AM-DL-AAC downloads
 mv-save-folder: AM-DL-MV downloads
 max-memory-limit: 256 # MB
-template-decrypt: false
-key-server: "127.0.0.1:40020"
-decrypt-m3u8-port: "127.0.0.1:10020"
-get-m3u8-port: "127.0.0.1:20020"
-get-m3u8-from-device: true
-get-account-port: "127.0.0.1:30020"
+template-decrypt: true
+key-server: "127.0.0.1:12340/key"
+decrypt-m3u8-port: "127.0.0.1:12340"
+get-m3u8-port: "127.0.0.1:12340"
+get-m3u8-from-device: false
+get-account-port: "127.0.0.1:12340"
 get-account-from-device: false   #if set true,will auto get media-user-token
 
 # set to 'true' to exit on error instead of requiring manual intervention. (for using this program in scripts)

--- a/utils/runv4/amtd.go
+++ b/utils/runv4/amtd.go
@@ -43,7 +43,7 @@ func (t *template) prepare() {
 	})
 }
 
-type templateResponse struct {
+type templateData struct {
 	Ctx   string `json:"ctx"`
 	State string `json:"state"`
 	RCX   string `json:"rcx"`
@@ -53,8 +53,30 @@ type templateResponse struct {
 	RBP   string `json:"rbp"`
 }
 
+type templateResponse struct {
+	Ctx   string        `json:"ctx"`
+	State string        `json:"state"`
+	RCX   string        `json:"rcx"`
+	RAX   string        `json:"rax"`
+	RDX   string        `json:"rdx"`
+	R9    string        `json:"r9"`
+	RBP   string        `json:"rbp"`
+	Data  *templateData `json:"data"`
+}
+
 func fetchTemplate(server, adam, uri string) (*template, error) {
-	endpoint := "http://" + server + "/?adamId=" + url.QueryEscape(adam) + "&uri=" + url.QueryEscape(uri)
+	// Support both old wrapper (host:port, uses /) and wrapper-lite (host:port/key).
+	// If the server string contains a path (e.g. "127.0.0.1:12340/key"), use it;
+	// otherwise fall back to the root path for backward compatibility.
+	base := "http://" + server
+	sep := "?"
+	if strings.Contains(server, "/") {
+		// Server already includes a path like "127.0.0.1:12340/key"
+		sep = "?"
+	} else {
+		base += "/"
+	}
+	endpoint := base + sep + "adamId=" + url.QueryEscape(adam) + "&uri=" + url.QueryEscape(uri)
 	client := http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Get(endpoint)
 	if err != nil {
@@ -64,15 +86,31 @@ func fetchTemplate(server, adam, uri string) (*template, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("key server returned %s", resp.Status)
 	}
-	var data templateResponse
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+	var respData templateResponse
+	if err := json.NewDecoder(resp.Body).Decode(&respData); err != nil {
 		return nil, err
 	}
-	ctxRaw, err := base64.StdEncoding.DecodeString(data.Ctx)
+
+	// Wrapper-lite wraps response inside "data": {"ctx": ..., "state": ...}
+	// Old wrapper returns flat fields: {"ctx": ..., "state": ...}
+	td := &templateData{
+		Ctx:   respData.Ctx,
+		State: respData.State,
+		RCX:   respData.RCX,
+		RAX:   respData.RAX,
+		RDX:   respData.RDX,
+		R9:    respData.R9,
+		RBP:   respData.RBP,
+	}
+	if respData.Data != nil && respData.Data.Ctx != "" {
+		td = respData.Data
+	}
+
+	ctxRaw, err := base64.StdEncoding.DecodeString(td.Ctx)
 	if err != nil || len(ctxRaw) < 0x8000 {
 		return nil, errors.New("invalid ctx in key-server response")
 	}
-	stateRaw, err := base64.StdEncoding.DecodeString(data.State)
+	stateRaw, err := base64.StdEncoding.DecodeString(td.State)
 	if err != nil || len(stateRaw) < 0x2000 {
 		return nil, errors.New("invalid state in key-server response")
 	}
@@ -81,23 +119,23 @@ func fetchTemplate(server, adam, uri string) (*template, error) {
 		n, err := strconv.ParseUint(value, 16, 64)
 		return u32(n), err
 	}
-	rcx, err := parse(data.RCX)
+	rcx, err := parse(td.RCX)
 	if err != nil {
 		return nil, err
 	}
-	rax, err := parse(data.RAX)
+	rax, err := parse(td.RAX)
 	if err != nil {
 		return nil, err
 	}
-	rdx, err := parse(data.RDX)
+	rdx, err := parse(td.RDX)
 	if err != nil {
 		return nil, err
 	}
-	r9, err := parse(data.R9)
+	r9, err := parse(td.R9)
 	if err != nil {
 		return nil, err
 	}
-	rbp, err := parse(data.RBP)
+	rbp, err := parse(td.RBP)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/runv4/runv4.go
+++ b/utils/runv4/runv4.go
@@ -67,11 +67,10 @@ func downloadWithResume(ctx context.Context, client *http.Client, fileUrl string
 
 	buf := &bytes.Buffer{}
 	var offset int64
-	backoff := 2 * time.Second
+	backoff := time.Duration(0)
 
 	for attempt := 1; attempt <= downloadMaxAttempts; attempt++ {
-		if attempt > 1 {
-			fmt.Printf("Download interrupted at %d/%d bytes, retrying in %v\n", offset, totalLen, backoff)
+		if attempt > 1 && backoff > 0 {
 			select {
 			case <-ctx.Done():
 				return nil, ctx.Err()
@@ -89,14 +88,14 @@ func downloadWithResume(ctx context.Context, client *http.Client, fileUrl string
 			attemptCancel()
 			return nil, err
 		}
-		req.Header = header
-		if offset > 0 {
-			req.Header.Set("Range", fmt.Sprintf("bytes=%d-", offset)) // 断点续传
-		}
+		req.Header = header.Clone()
+		// Always set Range header so Apple CDN streams the full file without 4MB cutoff
+		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", offset))
 
 		resp, err := client.Do(req)
 		if err != nil {
 			attemptCancel()
+			backoff = 1 * time.Second
 			continue
 		}
 		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
@@ -130,6 +129,12 @@ func downloadWithResume(ctx context.Context, client *http.Client, fileUrl string
 		}
 		if copyErr == nil {
 			copyErr = fmt.Errorf("short download: got %d of %d bytes", offset, totalLen)
+		}
+		// If bytes were successfully read, resume immediately without waiting 2 seconds
+		if n > 0 {
+			backoff = 0
+		} else {
+			backoff = 1 * time.Second
 		}
 	}
 	return nil, fmt.Errorf("download failed after %d attempts (got %d/%d bytes)",
@@ -188,6 +193,7 @@ func Run(adamId string, playlistUrl string, outfile string, Config structs.Confi
 	req.Header = header
 
 	var body io.Reader
+	var totalLen int64
 	client := &http.Client{Timeout: timeout}
 	if optstimeout > 0 {
 		// create the timer before calling Do so that the timeout covers TCP handshake,
@@ -198,6 +204,7 @@ func Run(adamId string, playlistUrl string, outfile string, Config structs.Confi
 			return err
 		}
 		defer do.Body.Close()
+		totalLen = do.ContentLength
 		body = &TimedResponseBody{
 			timeout:   timeout,
 			timer:     timer,
@@ -209,10 +216,11 @@ func Run(adamId string, playlistUrl string, outfile string, Config structs.Confi
 		if err != nil {
 			return err
 		}
-		defer do.Body.Close()
-		if do.ContentLength < int64(Config.MaxMemoryLimit * 1024 * 1024) {
+		totalLen = do.ContentLength
+		do.Body.Close()
+		if totalLen < int64(Config.MaxMemoryLimit * 1024 * 1024) {
 			bar := progressbar.NewOptions64(
-				do.ContentLength,
+				totalLen,
 				progressbar.OptionClearOnFinish(),
 				progressbar.OptionSetElapsedTime(false),
 				progressbar.OptionSetPredictTime(false),
@@ -229,7 +237,7 @@ func Run(adamId string, playlistUrl string, outfile string, Config structs.Confi
 					BarEnd:        "",
 				}),
 			)
-			buffer, err := downloadWithResume(ctx, client, fileUrl.String(), header, do.ContentLength, bar)
+			buffer, err := downloadWithResume(ctx, client, fileUrl.String(), header, totalLen, bar)
 			if err != nil {
 				return err // 下载没完成就失败退出，绝不进入解密
 			}
@@ -241,8 +249,6 @@ func Run(adamId string, playlistUrl string, outfile string, Config structs.Confi
 		}
 	}
 
-	var totalLen int64
-	totalLen = do.ContentLength
 	//key Server
 	//keyServer := fmt.Sprintf("127.0.0.1:40020")
 	keyServer := Config.KeyServer


### PR DESCRIPTION
### Overview
This pull request addresses two issues in `utils/runv4`:
1. **Download Performance:** Fixes an issue where track downloads prematurely stop at 4 MB and pause for 2 seconds on every track.
2. **Key Server Compatibility:** Adds support for custom endpoint paths and standard enveloped JSON responses (`{"code": 0, "data": {...}}`) while **maintaining 100% backward compatibility** with existing classic wrapper setups.

---

### 1. Download Throughput & Stream Continuity (`runv4.go`)

#### The Problem:
When downloading tracks using `runv4`, every track was hitting:
Downloading... 13% (4.2/30 MB, 28 MB/s) Download interrupted at 4194016/30347133 bytes, retrying in 2s
- **Why 4 MB?** `downloadWithResume` previously only attached the `Range` header when `offset > 0`. Without an initial `Range: bytes=0-` header, Apple CDN treats the connection as a short streaming burst and closes the connection at 4,194,016 bytes (~4 MiB).
- **Why was it slow?** The retry loop applied an unconditional `time.After(backoff)` of 2 seconds before resuming. On an album with 12–15 songs, this added 25–30 seconds of pure idle waiting, even on fast connections (50+ MB/s).
- **Duplicate Connection:** Line 208 executed `client.Do(req)` to read `ContentLength`, but only deferred `Close()`, leaving a live connection open while `downloadWithResume` opened another.

#### The Fix:
- Always include `Range: bytes=%d-` from byte 0 so Apple CDN streams the complete audio file continuously.
- Reset `backoff = 0` whenever progress was made (`n > 0`), ensuring immediate resumption without sleep penalties if an interruption occurs.
- Close the probe response body immediately after capturing `ContentLength`.
- Properly scope `totalLen` across function branches.

---

### 2. Flexible Key-Server Compatibility (`amtd.go`)

#### The Problem:
- Currently, `fetchTemplate` assumes the key server always serves at root (`http://<server>/?adamId=...`). If a user configures a path (such as behind a reverse proxy or using alternative single-port backends like `wrapper-lite` at `/key`), it built malformed URLs like `/key/?adamId=...` causing `404 Not Found`.
- Furthermore, some backends return standard response envelopes:
  ```json
  { "code": 0, "msg": "SUCCESS", "data": { "ctx": "...", "state": "..." } }
Since templateResponse only parsed root fields, data.Ctx decoded to "", resulting in invalid ctx in key-server response.

####  The Fix:
fetchTemplate checks if the server configuration already includes a path and applies the query delimiter accordingly.
templateResponse now supports both the nested data schema and the legacy flat fields. If root fields are present, it uses them as before; if nested inside data, it unwraps them seamlessly.
#### Backward Compatibility
Existing wrapper (main branch) setups: Completely unaffected. Flat JSON responses and host:port root paths continue to work identically without needing any config changes.
New setups: Users now have the flexibility to route through reverse proxies or newer single-port endpoints like 127.0.0.1:12340/key.
####  Test Results
Tested with full album downloads (16-bit / 44.1kHz ALAC).
Confirmed tracks stream smoothly at full network speed without 4 MB interruptions.
Verified parallel template decryption works as expected.